### PR TITLE
on second thought

### DIFF
--- a/boot/mirah_compiler.mirah
+++ b/boot/mirah_compiler.mirah
@@ -648,7 +648,7 @@ super()
       break if _t == BaseParser.__ERROR__
       _t=(
         var = genvar
-        err = null
+        err = String(nil)
         xs = List(ts)
         b = "begin; _p#{var}=_pos; _t=nil; begin  # and\n"
         xs.each do |x|

--- a/boot/mirah_compiler.mmeta
+++ b/boot/mirah_compiler.mmeta
@@ -162,7 +162,7 @@ public parser MMetaCompiler {
 
     And indent ts=trans+ {
         var = genvar
-        err = null
+        err = String(nil)
         xs = List(ts)
         b = "begin; _p#{var}=_pos; _t=nil; begin  # and\n"
         xs.each do |x|

--- a/test/Mirah.mmeta
+++ b/test/Mirah.mmeta
@@ -859,7 +859,7 @@ parser MirahParser {
   }
 
   def stringConcat(strings:Object) {
-    result = nil
+    result = Object(nil)
     List(strings).each do |s|
       result = stringConcat(result, s)
     end


### PR DESCRIPTION
seems to me that a type shouldn't be assigned on variable initialization if the assignment is to nil / null. perhaps this failure is intentional? still seems odd / like a bug. but i'm new to mirah, so it may be that this is just a naive point of view. clarification would be awesome -- thanks in advance!
