### PR TITLE
Fix load path modifications in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 require 'ant'
 require 'rake/testtask'
 
-if File.exist?('../duby/lib/mirah_task.rb')
-  $: << '../duby/lib'
+if File.exist?('../mirah/lib/mirah_task.rb')
+  $: << '../mirah/lib'
 end
 
 require 'mirah_task'


### PR DESCRIPTION
Currently the Rakefile modifies the $LOAD_PATH to point to the Mirah source files in "../duby/lib". This patch updates that directory reference to a more reasonable/current naming of "../mirah/lib"
